### PR TITLE
Update security settings in storage module

### DIFF
--- a/storage_module/settings.py
+++ b/storage_module/settings.py
@@ -156,8 +156,8 @@ MESSAGE_TAGS = {
     message_constants.ERROR: 'alert-danger',
 }
 
-ALLOWED_HOSTS = ['http://*', 'https://*']
-CSRF_TRUSTED_ORIGINS = ['http://*', 'https://*']
+ALLOWED_HOSTS = ['http://datawarehouse.bhp.org.bw', 'https://datawarehouse.bhp.org.bw']
+CSRF_TRUSTED_ORIGINS = ['http://datawarehouse.bhp.org.bw', 'https://datawarehouse.bhp.org.bw']
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 

--- a/storage_module/settings.py
+++ b/storage_module/settings.py
@@ -26,8 +26,6 @@ SECRET_KEY = 'django-insecure-+mdx-9+^j)2@x-6a*a465+xmu35dy_iz&n+w=f-!vjf2ayz!#j
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
 APP_NAME = 'storage_module'
 
 ETC_DIR = os.path.join('/etc/', APP_NAME)
@@ -156,3 +154,12 @@ MESSAGE_TAGS = {
     message_constants.WARNING: 'alert-warning',
     message_constants.ERROR: 'alert-danger',
 }
+
+
+ALLOWED_HOSTS = ['http://*', 'https://*']
+CSRF_TRUSTED_ORIGINS = ['http://*', 'https://*']
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+
+SESSION_COOKIE_DOMAIN = 'datawarehouse.bhp.org.bw'
+CSRF_COOKIE_DOMAIN = 'datawarehouse.bhp.org.bw'

--- a/storage_module/settings.py
+++ b/storage_module/settings.py
@@ -10,8 +10,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 import configparser
-from pathlib import Path
 import os
+from pathlib import Path
+
 from django.contrib.messages import constants as message_constants
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -154,7 +155,6 @@ MESSAGE_TAGS = {
     message_constants.WARNING: 'alert-warning',
     message_constants.ERROR: 'alert-danger',
 }
-
 
 ALLOWED_HOSTS = ['http://*', 'https://*']
 CSRF_TRUSTED_ORIGINS = ['http://*', 'https://*']


### PR DESCRIPTION
Security settings in the storage_module have been reconfigured. The ALLOWED_HOSTS has been modified to accept all http and https URLs. CSRF_TRUSTED_ORIGINS, SESSION_COOKIE_SECURE, and CSRF_COOKIE_SECURE have been set. Further, the SESSION_COOKIE_DOMAIN and CSRF_COOKIE_DOMAIN have been updated to 'datawarehouse.bhp.org.bw'.