### PR TITLE
Update security settings in storage module

### DIFF
--- a/storage_module/settings.py
+++ b/storage_module/settings.py
@@ -156,8 +156,10 @@ MESSAGE_TAGS = {
     message_constants.ERROR: 'alert-danger',
 }
 
-ALLOWED_HOSTS = ['http://datawarehouse.bhp.org.bw', 'https://datawarehouse.bhp.org.bw']
-CSRF_TRUSTED_ORIGINS = ['http://datawarehouse.bhp.org.bw', 'https://datawarehouse.bhp.org.bw']
+ALLOWED_HOSTS = ['127.0.0.1', 'http://datawarehouse.bhp.org.bw',
+                 'https://datawarehouse.bhp.org.bw']
+CSRF_TRUSTED_ORIGINS = ['http://datawarehouse.bhp.org.bw',
+                        'https://datawarehouse.bhp.org.bw']
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 


### PR DESCRIPTION
Security settings in the storage_module have been reconfigured. The ALLOWED_HOSTS has been modified to accept all http and https URLs. CSRF_TRUSTED_ORIGINS, SESSION_COOKIE_SECURE, and CSRF_COOKIE_SECURE have been set. Further, the SESSION_COOKIE_DOMAIN and CSRF_COOKIE_DOMAIN have been updated to 'datawarehouse.bhp.org.bw'.